### PR TITLE
fix isAlphanumeric() function

### DIFF
--- a/server/src/main/kotlin/net/horizonsend/ion/server/miscellaneous/utils/Chat.kt
+++ b/server/src/main/kotlin/net/horizonsend/ion/server/miscellaneous/utils/Chat.kt
@@ -75,7 +75,7 @@ fun <T> Iterable<T>.joinToText(
 	return component
 }
 
-fun String.isAlphanumeric() = matches("^[a-zA-Z0-9]*$".toRegex())
+fun String.isAlphanumeric() = matches("^[a-z]*$".toRegex()) || matches("^[0-9]*$".toRegex()) || matches("^[a-z0-9]*$".toRegex())
 
 @Deprecated("Use Ion MiniMessage Extension Functions")
 fun String.text(): TextComponent = TextComponent(this)


### PR DESCRIPTION
Originally, the isAlphaNumeric() function only tested with 1 regex, which only returned true if the String contained all ranges (a-z, A-Z, 0-9, and the whitespace character)

It would always return false though, because the blueprint name was never able to contain capital letters (due to an earlier check)

The fix checks for (after removing -, _, and whitespace): purely alphabetic (a-z)
purely numeric (0-9)
alphanumeric (a-z & 0-9)

This fixes the problem with not allowing - or _ in the blueprint name.